### PR TITLE
Add padding to paragraph text

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,8 @@
 		}
 		p  {
 			font-size: 18px;
-
+			padding-left: 17px;
+			padding-right: 17px;
 		}
 		a {
 			color: rgb(58, 163, 227);


### PR DESCRIPTION
Text on smaller screens resizes all of the way towards the edges of the screen. The padding makes it appear the same way as the other text on the page.
